### PR TITLE
update macOS 13 deadline  

### DIFF
--- a/Nudge/com.github.macadmins.Nudge.macOS13.json
+++ b/Nudge/com.github.macadmins.Nudge.macOS13.json
@@ -16,8 +16,8 @@
           "aboutUpdateURL": "https://www.notion.so/figma/Nudge-macOS-Updates-08ff479f262542c09c26cf2ad9ac3551"
         }
       ],
-      "requiredInstallationDate": "2024-01-16T00:00:01Z",
-      "requiredMinimumOSVersion": "13.6.3",
+      "requiredInstallationDate": "2025-03-25T00:00:01Z",
+      "requiredMinimumOSVersion": "14.0.0",
       "targetedOSVersionsRule": "13"
     }
   ],
@@ -53,7 +53,7 @@
         "mainContentHeader": "Your device will restart during this update",
         "mainContentNote": "Important Notes About This Update",
         "mainContentSubHeader": "Updates can take around 20-40 minutes to complete.",
-        "mainContentText": "A fully up-to-date device ensures the security of Figma's data. Please update your macOS device within the allotted *Days Remaining To Update* in the left column of this window.\n\nTo begin the update, click the *Open Software Update* button and follow the prompts. Although recommended, you are not required to update to macOS Sonoma. For the latest version of Ventura, scroll down within Software Update to *Other Updates Available* and install from there.\n\nAdditional info about this can be found by clicking the *More Info About Updates At Figma* link.",
+        "mainContentText": "A fully up-to-date device ensures the security of Figma's data. Please update your macOS device within the allotted *Days Remaining To Update* in the left column of this window.\n\nTo begin the update, click the *Open Software Update* button and follow the prompts. Additional info about this can be found by clicking the *More Info About Updates At Figma* link.",
         "mainHeader": "Your device requires a macOS Security Update",
         "primaryQuitButtonText": "Later",
         "secondaryQuitButtonText": "I understand",


### PR DESCRIPTION
Adding a deadline for all remaining macOS 13 devices to update to at least 14. 